### PR TITLE
Fix/bug test projection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 With this repo you can reproduce the results introduced in these papers:
 
 ## Analyzing Fine-tuning Representation Shift for Multimodal LLMs Steering
-### [Paper](https://arxiv.org/abs/2501.03012) 
+### [Paper](https://arxiv.org/abs/2501.03012)
 <p align="center">
   <table>
     <tr>

--- a/src/analysis/feature_decomposition.py
+++ b/src/analysis/feature_decomposition.py
@@ -11,6 +11,7 @@ from analysis.multimodal_grounding import get_multimodal_grounding
 __all__ = [
     "get_feature_matrix",
     "decompose_activations",
+    "project_representations",
     "decompose_and_ground_activations",
 ]
 
@@ -172,3 +173,26 @@ def decompose_activations(
         comp_activ = 1 / (1 + model.transform(mat))
 
     return components, comp_activ, model
+
+
+def project_representations(
+    sample: torch.Tensor, analysis_model: Callable, decomposition_type: str = "nndl"
+) -> np.ndarray:
+    """
+    Input:
+        sample: torch tensor or numpy array object of shape (N_samples, Representation_dim). Should contain test representations
+        analysis_model: Already learnt sklearn dictionary learning / clustering object.
+        decomposition_type: Dictionary learning model type (Options: PCA, KMeans, Semi-NMF/Non-negative dict learning, Simple)
+    Output:
+        proj: numpy array of shape (N_samples, # components of analysis_model)
+    """
+    if isinstance(sample, torch.Tensor):
+        sample = sample.cpu().numpy()
+
+    assert isinstance(sample, np.ndarray), "sample should be of type np.ndarray"
+
+    projected_sample = analysis_model.transform(sample)
+    if decomposition_type in ["kmeans", "simple"]:
+        # Kmeans transforms to cluster distances and not "activations". 1/(1+x) transformation to view distances as activations
+        projected_sample = 1 / (1 + projected_sample)
+    return projected_sample

--- a/src/examples/concept_dictionary/feature_decomposition.sh
+++ b/src/examples/concept_dictionary/feature_decomposition.sh
@@ -4,15 +4,15 @@
 cd ~/xl-vlms
 
 #model_name=llava-hf/llava-1.5-7b-hf
-#model_name=allenai/Molmo-7B-D-0924
+model_name=allenai/Molmo-7B-D-0924
 #model_name=HuggingFaceM4/idefics2-8b
-model_name=Qwen/Qwen2-VL-7B-Instruct
+#model_name=Qwen/Qwen2-VL-7B-Instruct
 
 # Need to specify analysis type. This will decompose features, and extract both text, visual grounding
 analysis_name=decompose_activations_text_grounding_image_grounding
 
 # Specify path where you have saved features on training data
-saved_features_path=/home/parekh/features/save_hidden_states_for_token_of_interest_qwen2_train_generation_split_train.pth
+saved_features_path=/home/parekh/features/save_hidden_states_for_token_of_interest_molmo_train_generation_split_train.pth
 
 # Where to store details about extracted concepts. Default directory is results/
 results_filename=results_train
@@ -25,13 +25,13 @@ results_filename=results_train
 
 # Molmo-7B
 #feature_module=model.transformer.blocks.27
-#feature_module=model.transformer.ln_f
+feature_module=model.transformer.ln_f
 
 # Idefics2-8B
 #feature_module=model.text_model.norm
 
 # Qwen2-VL-7B
-feature_module=model.norm
+#feature_module=model.norm
 
 decomposition=snmf # Current options: snmf, kmeans, pca, simple
 n_concepts=20 # Size of dictionary learnt i.e. number of concepts

--- a/src/examples/concept_dictionary/feature_decomposition.sh
+++ b/src/examples/concept_dictionary/feature_decomposition.sh
@@ -4,9 +4,9 @@
 cd ~/xl-vlms
 
 #model_name=llava-hf/llava-1.5-7b-hf
-model_name=allenai/Molmo-7B-D-0924
+#model_name=allenai/Molmo-7B-D-0924
 #model_name=HuggingFaceM4/idefics2-8b
-#model_name=Qwen/Qwen2-VL-7B-Instruct
+model_name=Qwen/Qwen2-VL-7B-Instruct
 
 # Need to specify analysis type. This will decompose features, and extract both text, visual grounding
 analysis_name=decompose_activations_text_grounding_image_grounding
@@ -25,13 +25,13 @@ results_filename=results_train
 
 # Molmo-7B
 #feature_module=model.transformer.blocks.27
-feature_module=model.transformer.ln_f
+#feature_module=model.transformer.ln_f
 
 # Idefics2-8B
 #feature_module=model.text_model.norm
 
 # Qwen2-VL-7B
-#feature_module=model.norm
+feature_module=model.norm
 
 decomposition=snmf # Current options: snmf, kmeans, pca, simple
 n_concepts=20 # Size of dictionary learnt i.e. number of concepts

--- a/src/metrics/dictionary_learning_metrics.py
+++ b/src/metrics/dictionary_learning_metrics.py
@@ -32,7 +32,7 @@ def get_clip_score(
     metadata = list(metadata.values())[0]
     analysis_model = concepts_dict["analysis_model"]
     grounding_words = concepts_dict["text_grounding"]
-    projections = analysis_decomposition.project_test_sample(
+    projections = analysis_decomposition.project_representations(
         sample=features,
         analysis_model=analysis_model,
         decomposition_type=concepts_dict["decomposition_method"],


### PR DESCRIPTION
Two changes:
(1) ```src/analysis/feature_decomposition.py``` now includes ```project_representations()``` function used during evaluation and also useful for obtaining activations for any given sample. Evaluation script tested and should not give any error now.
(2) ```playground/concept_grounding_visualization.ipynb``` notebook now also includes illustration for how to obtain local interpretation visualization -- Qwen2-VL-7B ("Train" token)